### PR TITLE
Quickstart updates

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -29,7 +29,7 @@ use the mail list and Twitter account listed below.
 
 The <a href="https://github.com/lfe/docs/blob/master/images/logos/LispFlavoredErlang-large.png?raw=true">logo</a>
 that the site uses for Lisp Flavored Erlang was originally taken from
-one done by an individual who went ny the name  "Starexterminator" in 2009. You can get the original on the
+one done by an individual who went by the name  "Starexterminator" in 2009. You can get the original on the
 <a href="http://openclipart.org/detail/25974/green-mug-of-tea-by-anonymous-25974">Open
 Clip Art Library</a> site.
 

--- a/quick-start/2.md
+++ b/quick-start/2.md
@@ -95,7 +95,7 @@ our unit tests.
 Okay, we've got our tests passing and our project looks healthy. But what does
 it have in it?
 
-* a README file in ReStructured Text
+* a Markdown formatted README file
 * a ``Makefile``
 * the ``rebar.config`` file we mentioned earlier (this has all your project
   dependencies in it)
@@ -123,10 +123,13 @@ $ git status
 #   (use "git rm --cached <file>..." to unstage)
 #
 #   new file:   .gitignore
+#   new file:   .travis.yml
 #   new file:   Makefile
-#   new file:   README.rst
+#   new file:   README.md
 #   new file:   package.exs
 #   new file:   rebar.config
+#   new file:   resources/make/common.mk
+#   new file:   src/my-test-lib-util.lfe
 #   new file:   src/my-test-lib.app.src
 #   new file:   src/my-test-lib.lfe
 #   new file:   test/my-test-lib_tests.lfe

--- a/quick-start/3.md
+++ b/quick-start/3.md
@@ -63,17 +63,18 @@ though. Here's the starter project you have, with just the one module:
 It has a corresponding test module:
 
 ```cl
-(defmodule my-test-lib_tests
+(defmodule unit-my-test-lib-tests
+  (behaviour ltest-unit)
   (export all)
   (import
-    (from lfeunit-util
+    (from ltest
       (check-failed-assert 2)
       (check-wrong-assert-exception 2))))
 
-(include-lib "deps/lfeunit/include/lfeunit-macros.lfe")
+(include-lib "ltest/include/ltest-macros.lfe")
 
 (deftest my-adder
-  (is-equal 4 (my-test-lib:my-adder 2 2)))
+  (is-equal 4 (: my-test-lib my-adder 2 2)))
 ```
 
 Almost couldn't be simpler.
@@ -88,8 +89,8 @@ LFE source code:
 (defun print-result ()
   (receive
     ((tuple pid msg)
-      (io:format "Received message: '~s'~n" (list msg))
-      (io:format "Sending message to process ~p ...~n" (list pid))
+      (: io format '"Received message: '~s'~n" (list msg))
+      (: io format '"Sending message to process ~p ...~n" (list pid))
       (! pid (tuple msg))
       (print-result))))
 
@@ -107,7 +108,7 @@ If you'd like to learn more about using the LFE REPL, be sure to read the
 <a href="http://docs.lfe.io/user-guide/intro/2.html">REPL Section</a> of the
 User Guide.
 
-If you want to step through a tutorial on Erlang's light-weight threds (per the
+If you want to step through a tutorial on Erlang's light-weight threads (per the
 example code above), you'll want to read
 <a href="http://docs.lfe.io/tutorials/processes/1.html">this tutorial</a>.
 

--- a/quick-start/4.md
+++ b/quick-start/4.md
@@ -42,10 +42,6 @@ you can skip the deps with the following targets:
 There are other interesting ``make`` targets tucked in the ``Makefile``, and
 you can learn more about how to manage LFE projects by checking them out.
 
-One thing to keep in mind for future reference: if you add new deps to your
-``rebar.confg`` file, you'll need to update the ``ERL_LIBS`` in your
-``Makefile`` to include them.
-
 Read more about setting up a development environment
 <a href="http://docs.lfe.io/user-guide/intro/4.html">here</a>.
 


### PR DESCRIPTION
Most of these are minor typo fixes that I saw when working through the quick start guide. The two changes that I'm least comfortable with are the code updates and the ERL_LIB note. I noticed that the generated code and the messenger-back example had changed since the documentation was written. The main change was the switch from the (module:function args) form to (: module function args). Since both look like they work, I assumed that there must be a preference for the latter form. As for the ERL_LIB note, it really looked like this had been fixed. Please ignore these changes if I interpreted incorrectly.