### PR TITLE
fix typo in user guide -> s/read/ready

### DIFF
--- a/user-guide/intro/2.md
+++ b/user-guide/intro/2.md
@@ -107,7 +107,7 @@ Once you're in the REPL, it's just a matter of entering code:
 
 Note that you can't define modules from the REPL; you'll have to put
 those in a module file and compile or ```slurp``` the file from the
-REPL. Are you read for a real `defun` time? Here we go!
+REPL. Are you ready for a real `defun` time? Here we go!
 
 ```cl
 > (defun exp (x y)


### PR DESCRIPTION
Fix a tiny typo.