### PR TITLE
Fix lfetool install command

### DIFF
--- a/user-guide/intro/4.md
+++ b/user-guide/intro/4.md
@@ -51,7 +51,7 @@ Here's how to download and install it:
 
 ```bash
 $ curl -L -o ./lfetool https://raw.github.com/lfe/lfetool/master/lfetool
-$ bash lfetool install /usr/local/bin
+$ bash lfetool install lfetool /usr/local/bin
 ```
 
 If you already have ``lfetool`` installed, but it's been a while, you should


### PR DESCRIPTION
When just doing `bash lfetool install /usr/local/bin` it returns the error "Unknown context: /usr/local/bin".
Adding `bash lfetool install lfetool /usr/local/bin` the script installs correctly.