### PR TITLE
Update docs to reflect changes in docs-generating module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ ok
 To generate the docs to dev:
 
 ```cl
-lfe> (docs:gen-dev)
+lfe> (docs-cli:gen-dev)
 Created docs/dev/index.html.
 ...
 ok
@@ -148,7 +148,7 @@ Or to generate the static files to prod (the `current` directory; this is
 only done when promoting dev to stable):
 
 ```cl
-lfe> (docs:gen)
+lfe> (docs-cli:gen)
 Created docs/current/index.html.
 ...
 ok
@@ -158,7 +158,13 @@ To run a local copy of the development server and view your work at
 [http://localhost:8080](http://localhost:8080), run the following:
 
 ```bash
-lfe> (docs:httpd)
+lfe> (docs-cli:start-httpd)
+ok
+```
+or for dev server
+
+```bash
+lfe> (docs-cli:gen-dev-httpd)
 ok
 ```
 
@@ -216,21 +222,21 @@ following steps outline how to add new content to the LFE Documentation site.
 **Generation & Testing**
 
 1. Start up the LFE REPL (e.g., `make repl`).
-1. Generate the static content with `(docs:gen-dev)`.
-1. Serve the newly generated content with `(docs:httpd)`.
+1. Generate the static content with `(docs-cli:gen-dev)`.
+1. Serve the newly generated content with `(docs-cli:httpd)`.
 1. Or do all of those with one target: `make serve-dev`.
 1. Visit
    [http://localhost:8080/dev/index.html](http://localhost:8080/dev/index.html)
    and any other pages you need to test.
 1. Once you are sure it's good, commit the changes.
 
-*Caution*: Do not run `(docs:gen)`, as that will generate an updated stable
+*Caution*: Do not run `(docs-cli:gen)`, as that will generate an updated stable
 version of the docs (the contents of the `current`) directory. That is only
 done prior to a new release of LFE and/or the documentation site. Any PRs that
 update `current` will not be approved until those changes are removed (modulo
 typo fixes and the like).
 
-If you have called `(docs:gen)` by accident, simply do a `git checkout` of the
+If you have called `(docs-cli:gen)` by accident, simply do a `git checkout` of the
 `current` dir to undo the docs regen.
 
 **Submission**


### PR DESCRIPTION
While checking out the contribution and building section of README.md, exactly **In the REPL** section. There were ways to generate the docs to dev which said `(docs:gen-dev)` which caused 
`exception error : undefined function  docs/1`
Upon checking out gen.mk file, I found the correct code to be `(docs-cli:gen-dev)`.